### PR TITLE
Permitir editar respuesta del formulario RSVP

### DIFF
--- a/index.html
+++ b/index.html
@@ -97,6 +97,9 @@
           <button type="submit" class="btn ghost" data-response="No">no puedo</button>
         </div>
         <p id="confirmation-message" class="confirmation-message" role="status" aria-live="polite"></p>
+        <button type="button" id="reset-response" class="btn link" data-skip-disable="true" hidden>
+          editar respuesta
+        </button>
       </form>
     </section>
 

--- a/style.css
+++ b/style.css
@@ -309,7 +309,36 @@ input[type='number']:focus-visible {
   transform: translateY(-2px);
 }
 
-.btn:focus-visible {
+.btn.link {
+  background: transparent;
+  border: none;
+  color: var(--color-accent);
+  padding: 0;
+  justify-content: flex-start;
+  font-size: 0.9rem;
+  font-weight: 600;
+  letter-spacing: 0.02em;
+  text-transform: lowercase;
+  box-shadow: none;
+  align-self: flex-start;
+}
+
+.btn.link:hover,
+.btn.link:focus-visible {
+  transform: none;
+  box-shadow: none;
+}
+
+.btn.link:hover {
+  text-decoration: underline;
+}
+
+.btn.link:focus-visible {
+  outline: 2px solid var(--color-accent);
+  outline-offset: 2px;
+}
+
+.btn:not(.link):focus-visible {
   outline: 2px solid var(--color-accent-alt);
   outline-offset: 2px;
 }


### PR DESCRIPTION
## Summary
- mostrar un mensaje visible cuando la respuesta ya está registrada
- añadir un botón para desbloquear el formulario y permitir editar la respuesta
- aplicar estilos al nuevo botón de acción secundaria del formulario

## Testing
- playwright script to verify locked/unlocked states

------
https://chatgpt.com/codex/tasks/task_e_68dfa93ab3bc832d9c447b9223d73f82