### PR TITLE
Replace intro envelope with interactive wax seal reveal

### DIFF
--- a/app.js
+++ b/app.js
@@ -11,134 +11,6 @@ const database = window.DB;
 const { ref, push } = window.firebaseRTDB || {};
 const languageButtons = document.querySelectorAll('.lang-button[data-language]');
 
-const envelopeOverlay = document.querySelector('[data-envelope-overlay]');
-const envelopeParallax = envelopeOverlay?.querySelector('[data-envelope-parallax]');
-const enterButton = envelopeOverlay?.querySelector('[data-enter-button]');
-const prefersReducedMotion = window.matchMedia
-  ? window.matchMedia('(prefers-reduced-motion: reduce)').matches
-  : false;
-const pointerFineQuery = window.matchMedia ? window.matchMedia('(pointer: fine)') : null;
-
-if (envelopeOverlay) {
-  let envelopeOpened = false;
-  let parallaxFrame = null;
-  const parallaxEnabled = !prefersReducedMotion && Boolean(pointerFineQuery?.matches);
-
-  const enableEnterButton = () => {
-    if (!enterButton) return;
-    enterButton.disabled = false;
-    enterButton.removeAttribute('aria-hidden');
-    enterButton.removeAttribute('tabindex');
-  };
-
-  const focusEnterButton = () => {
-    if (!enterButton || enterButton.disabled) return;
-    enterButton.focus({ preventScroll: true });
-  };
-
-  const resetParallax = () => {
-    if (!envelopeParallax) return;
-    envelopeParallax.style.setProperty('--parallax-rotate-x', '0deg');
-    envelopeParallax.style.setProperty('--parallax-rotate-y', '0deg');
-    envelopeParallax.style.setProperty('--parallax-translate', '0px');
-    parallaxFrame = null;
-  };
-
-  const handleParallax = (event) => {
-    if (!parallaxEnabled || !envelopeParallax) return;
-    const bounds = envelopeParallax.getBoundingClientRect();
-    const offsetX = (event.clientX - bounds.left) / bounds.width - 0.5;
-    const offsetY = (event.clientY - bounds.top) / bounds.height - 0.5;
-
-    const rotateX = (-offsetY * 6).toFixed(2);
-    const rotateY = (offsetX * 6).toFixed(2);
-    const translate = (-offsetY * 14).toFixed(2);
-
-    if (parallaxFrame) {
-      window.cancelAnimationFrame(parallaxFrame);
-    }
-
-    parallaxFrame = window.requestAnimationFrame(() => {
-      envelopeParallax.style.setProperty('--parallax-rotate-x', `${rotateX}deg`);
-      envelopeParallax.style.setProperty('--parallax-rotate-y', `${rotateY}deg`);
-      envelopeParallax.style.setProperty('--parallax-translate', `${translate}px`);
-      parallaxFrame = null;
-    });
-  };
-
-  const openEnvelope = ({ instant = false } = {}) => {
-    if (envelopeOpened) return;
-    envelopeOpened = true;
-    envelopeOverlay.classList.add('is-opening', 'is-open');
-    envelopeOverlay.setAttribute('aria-hidden', 'false');
-    document.body.classList.remove('envelope-locked');
-
-    if (instant) {
-      enableEnterButton();
-      window.requestAnimationFrame(focusEnterButton);
-      return;
-    }
-
-    window.setTimeout(() => {
-      enableEnterButton();
-    }, 560);
-
-    window.setTimeout(() => {
-      focusEnterButton();
-    }, 900);
-  };
-
-  const dismissOverlay = () => {
-    envelopeOverlay.classList.add('is-dismissed');
-    envelopeOverlay.setAttribute('aria-hidden', 'true');
-    resetParallax();
-    window.setTimeout(() => {
-      envelopeOverlay.remove();
-    }, 480);
-  };
-
-  envelopeOverlay.addEventListener('click', (event) => {
-    if (event.target instanceof HTMLElement && event.target.closest('[data-enter-button]')) {
-      return;
-    }
-    openEnvelope();
-  });
-
-  envelopeOverlay.addEventListener('keydown', (event) => {
-    if (event.key === 'Enter' || event.key === ' ') {
-      event.preventDefault();
-      openEnvelope();
-    }
-  });
-
-  if (enterButton) {
-    enterButton.setAttribute('aria-hidden', 'true');
-    enterButton.setAttribute('tabindex', '-1');
-    enterButton.addEventListener('click', (event) => {
-      event.stopPropagation();
-      const targetSection = document.querySelector('#inicio');
-      if (targetSection) {
-        targetSection.scrollIntoView({ behavior: prefersReducedMotion ? 'auto' : 'smooth' });
-      }
-      dismissOverlay();
-    });
-  }
-
-  if (parallaxEnabled && envelopeOverlay) {
-    envelopeOverlay.addEventListener('mousemove', handleParallax);
-    envelopeOverlay.addEventListener('mouseleave', resetParallax);
-  }
-
-  const focusTarget = prefersReducedMotion && enterButton ? enterButton : envelopeOverlay;
-
-  window.setTimeout(() => {
-    focusTarget?.focus({ preventScroll: true });
-  }, prefersReducedMotion ? 0 : 200);
-
-  if (prefersReducedMotion) {
-    openEnvelope({ instant: true });
-  }
-}
 
 const translations = {
   es: {
@@ -187,13 +59,7 @@ const translations = {
     'messages.thankYouNo': 'Una pena, te echaremos de menos.',
     'messages.saveError': 'No hemos podido guardar tu respuesta. Por favor, inténtalo de nuevo dentro de un momento.',
     'messages.responseExists': 'Ya tenemos tu respuesta registrada. ¡Gracias!',
-    'messages.firebaseUnavailable': 'Firebase RTDB no está disponible.',
-    'envelope.instruction': 'toca o haz clic para abrir',
-    'envelope.ariaLabel': 'Abrir invitación',
-    'envelope.letter': 'abre la invitación',
-    'envelope.letterHeading': 'Cintia & Andrea',
-    'envelope.letterBody': 'Sí, nos casamos.',
-    'envelope.enter': 'Entrar'
+    'messages.firebaseUnavailable': 'Firebase RTDB no está disponible.'
   },
   it: {
     'head.title': 'Cintia & Andrea · sì, ci sposiamo.',
@@ -241,13 +107,7 @@ const translations = {
     'messages.thankYouNo': 'Che peccato, ci mancherai.',
     'messages.saveError': 'Non siamo riusciti a salvare la tua risposta. Riprova tra qualche istante.',
     'messages.responseExists': 'Abbiamo già registrato la tua risposta. Grazie!',
-    'messages.firebaseUnavailable': 'Firebase RTDB non è disponibile.',
-    'envelope.instruction': 'tocca o fai clic per aprire',
-    'envelope.ariaLabel': "Apri l'invito",
-    'envelope.letter': "apri l'invito",
-    'envelope.letterHeading': 'Cintia & Andrea',
-    'envelope.letterBody': 'Sì, ci sposiamo.',
-    'envelope.enter': 'Entra'
+    'messages.firebaseUnavailable': 'Firebase RTDB non è disponibile.'
   }
 };
 

--- a/index.html
+++ b/index.html
@@ -9,25 +9,445 @@
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600&family=Poppins:wght@400;500;600&family=Space+Grotesk:wght@500;600;700&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="style.css">
 </head>
-<body class="envelope-locked">
-  <div class="envelope-overlay" data-envelope-overlay role="button" tabindex="0" data-i18n-attr="aria-label:envelope.ariaLabel">
-    <div class="envelope-parallax" data-envelope-parallax>
-      <div class="envelope" data-envelope aria-hidden="true">
-        <div class="envelope-shadow"></div>
-        <div class="envelope-pocket"></div>
-        <div class="envelope-letter">
-          <div class="letter-card">
-            <p class="letter-heading" data-i18n="envelope.letterHeading">Cintia &amp; Andrea</p>
-            <p class="letter-body" data-i18n="envelope.letterBody">Sí, nos casamos.</p>
-          </div>
-        </div>
-        <div class="envelope-lid"></div>
-        <div class="envelope-front"></div>
+<body class="wax-intro-locked">
+  <section id="waxIntro" class="wax-intro" aria-labelledby="inviteTitle">
+    <h1 id="inviteTitle" class="sr-only">Invitación</h1>
+    <div class="wax-intro__center">
+      <button class="wax-seal" id="waxSeal" type="button" aria-label="Abrir invitación" aria-expanded="false">
+        <svg class="wax-seal__svg" viewBox="0 0 320 320" aria-hidden="true" focusable="false">
+          <defs>
+            <radialGradient id="waxGradient" cx="50%" cy="38%" r="65%">
+              <stop offset="0%" stop-color="#f7d6c4" />
+              <stop offset="45%" stop-color="#e5a18a" />
+              <stop offset="100%" stop-color="#c25c49" />
+            </radialGradient>
+            <radialGradient id="waxHighlight" cx="32%" cy="28%" r="55%">
+              <stop offset="0%" stop-color="rgba(255, 255, 255, 0.55)" />
+              <stop offset="100%" stop-color="rgba(255, 255, 255, 0)" />
+            </radialGradient>
+          </defs>
+          <circle cx="160" cy="160" r="140" fill="url(#waxGradient)" />
+          <path d="M64 170c18 58 64 92 96 92s70-20 96-60 20-92-18-120-88-30-118-4-74 34-56 92z" fill="url(#waxHighlight)" />
+          <text x="50%" y="50%" dominant-baseline="middle" text-anchor="middle" class="wax-seal__initials">C · A</text>
+        </svg>
+      </button>
+      <p class="helper">Toca o haz clic</p>
+      <div class="reveal" hidden>
+        <h2 class="names"></h2>
+        <p class="subtitle"></p>
+        <button id="enterBtn" class="enter-btn" type="button">Entrar</button>
       </div>
     </div>
-    <button class="envelope-enter" type="button" data-enter-button disabled aria-hidden="true" tabindex="-1" data-i18n="envelope.enter">Entrar</button>
-    <p class="envelope-instruction" data-i18n="envelope.instruction">toca o haz clic para abrir</p>
-  </div>
+  </section>
+  <style>
+    /* --- Wax intro component --- */
+    #waxIntro {
+      --wax-bg: radial-gradient(circle at 40% 30%, rgba(255, 255, 255, 0.85), rgba(248, 242, 235, 0.92) 45%, rgba(242, 234, 226, 0.98) 75%);
+      --wax-surface: #fcf7f1;
+      --wax-text: #3a2a28;
+      --wax-seal-shadow: rgba(103, 40, 34, 0.45);
+      --wax-helper: rgba(58, 42, 40, 0.72);
+      --wax-highlight: rgba(255, 255, 255, 0.7);
+      --wax-melt-duration: 820ms;
+      --wax-reveal-duration: 360ms;
+      --wax-out-duration: 420ms;
+    }
+
+    .wax-intro {
+      position: fixed;
+      inset: 0;
+      z-index: 1000;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      padding: clamp(1.5rem, 7vw, 3rem);
+      background: var(--wax-bg);
+      backdrop-filter: blur(14px);
+      color: var(--wax-text);
+      text-align: center;
+      font-family: var(--font-body, 'Poppins', system-ui, sans-serif);
+      transition: opacity var(--wax-out-duration) ease, visibility var(--wax-out-duration) ease;
+      touch-action: manipulation;
+    }
+
+    .wax-intro.is-dismissed {
+      opacity: 0;
+      visibility: hidden;
+      pointer-events: none;
+    }
+
+    .wax-intro__center {
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      gap: clamp(1rem, 4vw, 2.25rem);
+      max-width: 480px;
+      width: min(100%, 420px);
+    }
+
+    .wax-seal {
+      position: relative;
+      width: min(72vw, 280px);
+      aspect-ratio: 1 / 1;
+      padding: 0;
+      border: none;
+      background: transparent;
+      cursor: pointer;
+      transition: transform 280ms ease, filter 280ms ease;
+      transform: translateZ(0);
+    }
+
+    .wax-seal:focus-visible {
+      outline: 3px solid rgba(255, 255, 255, 0.75);
+      outline-offset: 6px;
+      box-shadow: 0 0 0 4px rgba(107, 52, 46, 0.38);
+    }
+
+    .wax-seal::before {
+      content: '';
+      position: absolute;
+      inset: 14%;
+      border-radius: 50%;
+      background: rgba(255, 255, 255, 0.12);
+      filter: blur(6px);
+      opacity: 0.4;
+      pointer-events: none;
+    }
+
+    .wax-seal::after {
+      content: '';
+      position: absolute;
+      top: 96%;
+      left: 50%;
+      width: clamp(12px, 3vw, 20px);
+      height: clamp(44px, 12vw, 70px);
+      border-radius: 999px;
+      background: linear-gradient(180deg, rgba(244, 207, 184, 0.92), rgba(199, 92, 73, 0.65));
+      opacity: 0;
+      transform: translate(-50%, -15%) scaleY(0.3);
+      filter: blur(0.8px);
+      pointer-events: none;
+    }
+
+    .wax-seal__svg {
+      width: 100%;
+      height: 100%;
+      display: block;
+      filter:
+        drop-shadow(0 18px 35px rgba(58, 24, 22, 0.3))
+        drop-shadow(0 6px 12px rgba(255, 255, 255, 0.16));
+    }
+
+    .wax-seal__initials {
+      font-family: var(--font-heading, 'Space Grotesk', 'Poppins', sans-serif);
+      font-size: clamp(2.4rem, 8vw, 3.4rem);
+      fill: #fff6f3;
+      letter-spacing: 0.28em;
+      font-weight: 600;
+    }
+
+    .helper {
+      margin: 0;
+      font-size: clamp(1rem, 3.6vw, 1.1rem);
+      color: var(--wax-helper);
+      text-transform: lowercase;
+      transition: opacity 320ms ease;
+    }
+
+    .helper.is-hidden {
+      opacity: 0;
+      visibility: hidden;
+    }
+
+    .reveal {
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      gap: clamp(0.65rem, 3vw, 1.1rem);
+      text-align: center;
+      opacity: 0;
+      transform: translateY(16px);
+      transition: opacity var(--wax-reveal-duration) ease, transform var(--wax-reveal-duration) ease;
+    }
+
+    .reveal[hidden] {
+      display: none;
+    }
+
+    .reveal.is-visible {
+      opacity: 1;
+      transform: translateY(0);
+    }
+
+    .names {
+      margin: 0;
+      font-family: var(--font-heading, 'Space Grotesk', 'Poppins', sans-serif);
+      font-size: clamp(1.9rem, 7vw, 2.6rem);
+      letter-spacing: 0.08em;
+      text-transform: uppercase;
+    }
+
+    .subtitle {
+      margin: 0;
+      font-size: clamp(1rem, 3.2vw, 1.1rem);
+      color: rgba(58, 42, 40, 0.72);
+    }
+
+    .subtitle[hidden] {
+      display: none;
+    }
+
+    .enter-btn {
+      margin-top: clamp(0.4rem, 2vw, 0.75rem);
+      padding: 0.75rem 1.9rem;
+      border: none;
+      border-radius: 999px;
+      background: linear-gradient(140deg, #3a2a28, #5d3a35);
+      color: #fdf6f1;
+      font-size: 1rem;
+      font-weight: 600;
+      letter-spacing: 0.08em;
+      text-transform: uppercase;
+      cursor: pointer;
+      transition: transform 180ms ease, box-shadow 180ms ease;
+    }
+
+    .enter-btn:hover,
+    .enter-btn:focus-visible {
+      transform: translateY(-2px);
+      box-shadow: 0 8px 20px rgba(47, 31, 28, 0.28);
+      outline: none;
+    }
+
+    .enter-btn:active {
+      transform: translateY(1px);
+    }
+
+    .wax-intro.is-revealed .wax-seal {
+      pointer-events: none;
+    }
+
+    .wax-intro.is-revealed .wax-seal,
+    .wax-intro.is-revealed .wax-seal__svg {
+      opacity: 0;
+      transition: opacity 240ms ease;
+    }
+
+    .wax-intro.is-revealed .helper {
+      opacity: 0;
+      visibility: hidden;
+    }
+
+    .wax-intro.is-melting .wax-seal {
+      animation: waxMelt var(--wax-melt-duration) forwards cubic-bezier(0.45, 0.05, 0.2, 0.99);
+    }
+
+    .wax-intro.is-melting .wax-seal::after {
+      animation: waxDrip var(--wax-melt-duration) forwards ease-in;
+    }
+
+    @keyframes waxMelt {
+      0% {
+        transform: scale(1) translateY(0);
+        opacity: 1;
+      }
+      40% {
+        transform: scale(1.05, 0.94) translateY(6px);
+      }
+      70% {
+        transform: scale(1.08, 0.88) translateY(18px);
+      }
+      100% {
+        transform: scale(1.12, 0.66) translateY(120px);
+        opacity: 0;
+      }
+    }
+
+    @keyframes waxDrip {
+      0% {
+        opacity: 0;
+        transform: translate(-50%, -15%) scaleY(0.3);
+      }
+      30% {
+        opacity: 1;
+        transform: translate(-50%, 15%) scaleY(0.8);
+      }
+      65% {
+        opacity: 1;
+        transform: translate(-50%, 60%) scale(0.9, 1.05);
+      }
+      100% {
+        opacity: 0;
+        transform: translate(-50%, 130%) scale(0.45, 1.2);
+      }
+    }
+
+    .sr-only {
+      position: absolute;
+      width: 1px;
+      height: 1px;
+      padding: 0;
+      margin: -1px;
+      overflow: hidden;
+      clip: rect(0, 0, 0, 0);
+      white-space: nowrap;
+      border: 0;
+    }
+
+    @media (min-width: 720px) {
+      .wax-intro__center {
+        max-width: 520px;
+      }
+    }
+
+    @media (prefers-reduced-motion: reduce) {
+      .wax-intro,
+      .wax-seal,
+      .reveal,
+      .enter-btn {
+        transition-duration: 0.01ms;
+        animation-duration: 0.01ms !important;
+      }
+
+      .wax-intro.is-melting .wax-seal,
+      .wax-intro.is-melting .wax-seal::after {
+        animation: none;
+      }
+    }
+  </style>
+  <script>
+    // --- Wax intro component behaviour ---
+    const COUPLE_NAMES = "Cintia & Andrea";
+    const SUBTITLE = "Vera (Almería) — 28 · 06 · 2026";
+    const DESTINATION = "/";
+
+    (function initWaxIntro() {
+      const waxIntro = document.getElementById('waxIntro');
+      const waxSeal = document.getElementById('waxSeal');
+      const helper = waxIntro?.querySelector('.helper');
+      const revealBlock = waxIntro?.querySelector('.reveal');
+      const namesEl = waxIntro?.querySelector('.names');
+      const subtitleEl = waxIntro?.querySelector('.subtitle');
+      const enterBtn = document.getElementById('enterBtn');
+      if (!waxIntro || !waxSeal || !revealBlock || !namesEl || !enterBtn) {
+        document.body.classList.remove('wax-intro-locked');
+        return;
+      }
+
+      enterBtn.disabled = true;
+
+      const motionMedia = window.matchMedia ? window.matchMedia('(prefers-reduced-motion: reduce)') : null;
+      let prefersReducedMotion = motionMedia?.matches ?? false;
+
+      motionMedia?.addEventListener('change', (event) => {
+        prefersReducedMotion = event.matches;
+      });
+
+      namesEl.textContent = COUPLE_NAMES;
+      if (subtitleEl) {
+        if (SUBTITLE) {
+          subtitleEl.textContent = SUBTITLE;
+          subtitleEl.hidden = false;
+        } else {
+          subtitleEl.hidden = true;
+        }
+      }
+
+      let isAnimating = false;
+      let isRevealed = false;
+
+      const hideHelper = () => {
+        if (!helper) return;
+        helper.classList.add('is-hidden');
+        helper.setAttribute('aria-hidden', 'true');
+      };
+
+      const focusEnter = () => {
+        window.requestAnimationFrame(() => {
+          enterBtn.focus({ preventScroll: true });
+        });
+      };
+
+      const reveal = () => {
+        if (isRevealed) return;
+        isRevealed = true;
+        waxIntro.classList.add('is-revealed');
+        waxIntro.classList.remove('is-melting');
+        waxSeal.disabled = true;
+        waxSeal.setAttribute('aria-expanded', 'true');
+        hideHelper();
+        revealBlock.hidden = false;
+        requestAnimationFrame(() => {
+          revealBlock.classList.add('is-visible');
+        });
+        enterBtn.disabled = false;
+        focusEnter();
+        isAnimating = false;
+      };
+
+      const startMelt = () => {
+        if (isAnimating || isRevealed) return;
+        isAnimating = true;
+        waxIntro.classList.add('is-melting');
+        hideHelper();
+
+        if (prefersReducedMotion) {
+          reveal();
+          return;
+        }
+
+        const handleAnimationEnd = (event) => {
+          if (event.target !== waxSeal || event.animationName !== 'waxMelt') return;
+          waxIntro.removeEventListener('animationend', handleAnimationEnd);
+          reveal();
+        };
+
+        waxIntro.addEventListener('animationend', handleAnimationEnd);
+      };
+
+      const dismissIntro = () => {
+        waxIntro.classList.add('is-dismissed');
+        waxIntro.setAttribute('aria-hidden', 'true');
+        document.body.classList.remove('wax-intro-locked');
+        window.setTimeout(() => {
+          waxIntro.remove();
+        }, 480);
+      };
+
+      const navigate = () => {
+        if (!DESTINATION) {
+          dismissIntro();
+          return;
+        }
+
+        if (DESTINATION.startsWith('#')) {
+          const target = document.querySelector(DESTINATION);
+          if (target) {
+            target.scrollIntoView({ behavior: prefersReducedMotion ? 'auto' : 'smooth' });
+            dismissIntro();
+            return;
+          }
+        }
+
+        dismissIntro();
+        window.location.assign(DESTINATION);
+      };
+
+      waxSeal.addEventListener('click', startMelt);
+      waxSeal.addEventListener('keydown', (event) => {
+        if (event.key === 'Enter' || event.key === ' ') {
+          event.preventDefault();
+          startMelt();
+        }
+      });
+
+      enterBtn.addEventListener('click', navigate);
+
+      window.requestAnimationFrame(() => {
+        waxSeal.focus({ preventScroll: true });
+      });
+    })();
+  </script>
   <nav class="site-nav" aria-label="Secciones de la invitación" data-i18n-attr="aria-label:nav.ariaLabel">
     <div class="nav-container">
       <span class="nav-brand">Cintia &amp; Andrea</span>

--- a/style.css
+++ b/style.css
@@ -18,11 +18,6 @@
   --spacing-xl: 4.5rem;
   --page-padding: clamp(1.5rem, 5vw, 2.5rem);
   --transition-fast: 140ms ease;
-  --envelope-ivory: #faf8f2;
-  --envelope-cream: #fff5e9;
-  --envelope-gold: #c9a86a;
-  --envelope-shadow: rgba(42, 42, 42, 0.18);
-  --envelope-highlight: rgba(255, 255, 255, 0.7);
 }
 
 *,
@@ -43,7 +38,7 @@ body {
   line-height: 1.6;
 }
 
-body.envelope-locked {
+body.wax-intro-locked {
   overflow: hidden;
 }
 
@@ -54,334 +49,22 @@ main,
   transition: opacity 0.6s ease, transform 0.6s ease;
 }
 
-body.envelope-locked .site-nav,
-body.envelope-locked .hero,
-body.envelope-locked main,
-body.envelope-locked .site-footer {
+body.wax-intro-locked .site-nav,
+body.wax-intro-locked .hero,
+body.wax-intro-locked main,
+body.wax-intro-locked .site-footer {
   opacity: 0;
   transform: translateY(24px);
   pointer-events: none;
 }
 
-body:not(.envelope-locked) .site-nav,
-body:not(.envelope-locked) .hero,
-body:not(.envelope-locked) main,
-body:not(.envelope-locked) .site-footer {
+body:not(.wax-intro-locked) .site-nav,
+body:not(.wax-intro-locked) .hero,
+body:not(.wax-intro-locked) main,
+body:not(.wax-intro-locked) .site-footer {
   opacity: 1;
   transform: none;
   pointer-events: auto;
-}
-
-.envelope-overlay {
-  position: fixed;
-  inset: 0;
-  z-index: 999;
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  justify-content: center;
-  gap: clamp(1.4rem, 4vw, 2.6rem);
-  padding: clamp(1.5rem, 6vw, 3rem);
-  background:
-    radial-gradient(circle at 15% 20%, rgba(255, 255, 255, 0.92), rgba(250, 248, 242, 0.88) 60%),
-    linear-gradient(140deg, rgba(201, 168, 106, 0.2), rgba(179, 147, 94, 0.1));
-  backdrop-filter: blur(12px);
-  color: var(--color-text);
-  cursor: pointer;
-  text-align: center;
-  font-family: 'Poppins', var(--font-body);
-  transition: opacity 0.45s ease, visibility 0.45s ease;
-  touch-action: manipulation;
-}
-
-.envelope-overlay::before {
-  content: '';
-  position: absolute;
-  inset: 0;
-  background: radial-gradient(circle at center, rgba(255, 255, 255, 0.18), transparent 55%);
-  pointer-events: none;
-}
-
-.envelope-overlay.is-opening,
-.envelope-overlay.is-open {
-  cursor: default;
-}
-
-.envelope-overlay.is-dismissed {
-  opacity: 0;
-  visibility: hidden;
-  pointer-events: none;
-}
-
-.envelope-overlay:focus-visible {
-  outline: 3px solid rgba(201, 168, 106, 0.7);
-  outline-offset: 6px;
-}
-
-.envelope-parallax {
-  position: relative;
-  width: clamp(240px, 52vw, 420px);
-  aspect-ratio: 4 / 3;
-  perspective: 1200px;
-  --parallax-rotate-x: 0deg;
-  --parallax-rotate-y: 0deg;
-  --parallax-translate: 0px;
-  transition: transform 0.5s ease;
-  transform:
-    translate3d(0, var(--parallax-translate), 0)
-    rotateX(clamp(-4deg, var(--parallax-rotate-x), 4deg))
-    rotateY(clamp(-4deg, var(--parallax-rotate-y), 4deg));
-}
-
-.envelope {
-  position: relative;
-  width: 100%;
-  height: 100%;
-  border-radius: 22px;
-  transform-style: preserve-3d;
-  background: linear-gradient(165deg, rgba(255, 249, 240, 0.9), rgba(248, 236, 215, 0.9));
-  box-shadow:
-    0 24px 36px rgba(42, 42, 42, 0.16),
-    inset 0 0 0 1px rgba(201, 168, 106, 0.35);
-  overflow: visible;
-  transition: transform 0.75s cubic-bezier(0.32, 0.72, 0, 1);
-}
-
-.envelope-shadow {
-  position: absolute;
-  inset: 18% 6% 6%;
-  border-radius: 28px;
-  background: radial-gradient(circle at 50% 20%, rgba(42, 42, 42, 0.18), transparent 70%);
-  filter: blur(20px);
-  transform: translate3d(0, 18px, -1px);
-  z-index: 0;
-}
-
-.envelope-pocket {
-  position: absolute;
-  inset: 20% 6% 12%;
-  border-radius: 18px 18px 22px 22px;
-  background:
-    linear-gradient(160deg, rgba(250, 242, 227, 0.95), rgba(238, 221, 193, 0.95)),
-    repeating-linear-gradient(0deg, rgba(255, 255, 255, 0.08), rgba(255, 255, 255, 0.08) 6px, rgba(255, 255, 255, 0) 6px, rgba(255, 255, 255, 0) 12px);
-  box-shadow:
-    inset 0 0 0 1px rgba(201, 168, 106, 0.3),
-    inset 0 12px 22px rgba(255, 255, 255, 0.5),
-    inset 0 -18px 24px rgba(179, 140, 82, 0.12);
-  z-index: 1;
-  overflow: hidden;
-}
-
-.envelope-pocket::before {
-  content: '';
-  position: absolute;
-  inset: 0;
-  background: radial-gradient(circle at 50% 0%, rgba(255, 255, 255, 0.5), transparent 70%);
-  mix-blend-mode: screen;
-}
-
-.envelope-letter {
-  position: absolute;
-  inset: 24% 12% 18%;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  padding: clamp(1rem, 3.6vw, 1.8rem);
-  transform: translate3d(0, 46%, 0);
-  opacity: 0;
-  z-index: 2;
-  pointer-events: none;
-  transition:
-    transform 0.7s cubic-bezier(0.26, 0.68, 0.35, 0.99),
-    opacity 0.4s ease;
-}
-
-.letter-card {
-  width: 100%;
-  border-radius: 18px;
-  padding: clamp(1rem, 3.3vw, 1.6rem);
-  background:
-    linear-gradient(155deg, rgba(255, 253, 248, 0.96), rgba(245, 236, 220, 0.96)),
-    repeating-linear-gradient(90deg, rgba(0, 0, 0, 0.02) 0 1px, transparent 1px 3px);
-  box-shadow:
-    0 18px 34px rgba(42, 42, 42, 0.18),
-    inset 0 0 0 1px rgba(201, 168, 106, 0.24);
-}
-
-.letter-heading {
-  margin: 0 0 0.45rem;
-  font-size: clamp(1.1rem, 3.4vw, 1.5rem);
-  font-weight: 600;
-  letter-spacing: 0.18em;
-  text-transform: uppercase;
-  color: rgba(42, 42, 42, 0.88);
-}
-
-.letter-body {
-  margin: 0;
-  font-size: clamp(0.9rem, 2.6vw, 1.05rem);
-  letter-spacing: 0.12em;
-  text-transform: uppercase;
-  color: rgba(42, 42, 42, 0.6);
-}
-
-.envelope-lid {
-  position: absolute;
-  top: 10%;
-  left: 6%;
-  right: 6%;
-  height: 46%;
-  background:
-    linear-gradient(170deg, rgba(249, 234, 208, 1), rgba(233, 207, 166, 0.98)),
-    repeating-linear-gradient(120deg, rgba(255, 255, 255, 0.08) 0 4px, transparent 4px 9px);
-  clip-path: polygon(0 0, 100% 0, 50% 100%);
-  transform-origin: top center;
-  transform: rotateX(0deg);
-  backface-visibility: hidden;
-  box-shadow:
-    inset 0 -1px 0 rgba(201, 168, 106, 0.5),
-    inset 0 18px 22px rgba(255, 255, 255, 0.5);
-  transition: transform 0.65s cubic-bezier(0.32, 0.72, 0, 1);
-  z-index: 4;
-}
-
-.envelope-lid::after {
-  content: '';
-  position: absolute;
-  inset: 0;
-  background: linear-gradient(180deg, rgba(255, 255, 255, 0.45), transparent 65%);
-  mix-blend-mode: screen;
-}
-
-.envelope-front {
-  position: absolute;
-  inset: 34% 6% 10%;
-  background:
-    linear-gradient(185deg, rgba(248, 231, 201, 0.98), rgba(232, 205, 166, 0.98)),
-    repeating-linear-gradient(0deg, rgba(255, 255, 255, 0.06) 0 5px, transparent 5px 12px);
-  clip-path: polygon(0 22%, 50% 0, 100% 22%, 100% 100%, 0 100%);
-  border-radius: 0 0 18px 18px;
-  box-shadow:
-    inset 0 0 0 1px rgba(201, 168, 106, 0.32),
-    inset 0 16px 22px rgba(255, 255, 255, 0.4),
-    inset 0 -20px 30px rgba(176, 140, 90, 0.16);
-  z-index: 3;
-}
-
-.envelope-front::before {
-  content: '';
-  position: absolute;
-  inset: 0;
-  background: linear-gradient(160deg, rgba(255, 255, 255, 0.45), rgba(255, 255, 255, 0));
-  opacity: 0.7;
-}
-
-.envelope-front::after {
-  content: '';
-  position: absolute;
-  top: 22%;
-  left: 50%;
-  width: 12%;
-  height: 2px;
-  background: rgba(201, 168, 106, 0.55);
-  transform: translateX(-50%);
-}
-
-.envelope-instruction {
-  margin: 0;
-  font-size: 0.75rem;
-  letter-spacing: 0.24em;
-  text-transform: uppercase;
-  color: rgba(42, 42, 42, 0.55);
-}
-
-.envelope-enter {
-  border: none;
-  border-radius: 999px;
-  padding: 0.85rem 2.6rem;
-  font-size: 0.82rem;
-  letter-spacing: 0.18em;
-  text-transform: uppercase;
-  font-weight: 500;
-  background: linear-gradient(135deg, #d8b77b, #c9a86a);
-  color: var(--color-text);
-  box-shadow: 0 14px 26px rgba(201, 168, 106, 0.45);
-  opacity: 0;
-  transform: translateY(12px);
-  transition: transform 0.35s ease, opacity 0.35s ease;
-  transition-delay: 0s;
-  pointer-events: none;
-}
-
-.envelope-enter:focus-visible {
-  outline: 3px solid rgba(201, 168, 106, 0.75);
-  outline-offset: 4px;
-}
-
-.envelope-enter:disabled {
-  cursor: default;
-}
-
-.envelope-overlay.is-open .envelope {
-  transform: translate3d(0, -12px, 0);
-}
-
-.envelope-overlay.is-open .envelope-lid {
-  transform: rotateX(-128deg);
-}
-
-.envelope-overlay.is-open .envelope-letter {
-  transform: translate3d(0, -10%, 0);
-  opacity: 1;
-  transition-delay: 0.18s, 0.18s;
-  z-index: 5;
-}
-
-.envelope-overlay.is-open .envelope-enter {
-  opacity: 1;
-  transform: translateY(0);
-  pointer-events: auto;
-  transition-delay: 0.45s;
-}
-
-@media (max-width: 600px) {
-  .envelope-parallax {
-    width: clamp(220px, 78vw, 340px);
-  }
-
-  .letter-card {
-    padding: clamp(0.9rem, 5vw, 1.3rem);
-  }
-
-  .envelope-enter {
-    width: min(280px, 90vw);
-  }
-}
-
-@media (prefers-reduced-motion: reduce) {
-  .site-nav,
-  .hero,
-  main,
-  .site-footer,
-  .envelope-overlay,
-  .envelope-parallax,
-  .envelope,
-  .envelope-lid,
-  .envelope-letter,
-  .envelope-enter {
-    transition-duration: 0.01ms !important;
-    animation-duration: 0.01ms !important;
-  }
-
-  .envelope,
-  .envelope-letter,
-  .envelope-lid {
-    transform: none !important;
-  }
-
-  .envelope-letter {
-    opacity: 1 !important;
-  }
 }
 
 a {
@@ -853,5 +536,15 @@ input[type='number']:focus-visible {
 
   .form-actions {
     grid-template-columns: 1fr;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .site-nav,
+  .hero,
+  main,
+  .site-footer {
+    transition-duration: 0.01ms !important;
+    animation-duration: 0.01ms !important;
   }
 }


### PR DESCRIPTION
## Summary
- replace the envelope overlay with an accessible wax seal intro that reveals the invitation and entry button after the melt animation
- update shared styles to use the new wax intro lock and remove unused envelope-specific rules
- drop the envelope overlay logic and translations from the client script

## Testing
- Not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_6904bfb9f3f4832d8239b7cfe97e4d1b